### PR TITLE
Allow more versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.0",
-        "phpdocumentor/reflection-docblock": "4.2.*",
+        "phpdocumentor/reflection-docblock": "4.2.*|4.3.*",
         "phpdocumentor/type-resolver": "0.4.*",
-        "nikic/php-parser": "^2.0|^3.0"
+        "nikic/php-parser": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5|^7.0"


### PR DESCRIPTION
Allows more versions for `phpdocumentor/reflection-docblock` and `nikic/php-parser` as there currently is an issue with installing the package on the latest PHPUnit 7 and Mockery because of a conflict with `phpdocumentor/reflection-docblock`.